### PR TITLE
Tutorial archetype

### DIFF
--- a/archetypes/tutorial/index.md
+++ b/archetypes/tutorial/index.md
@@ -1,0 +1,66 @@
+---
+title: "{{ humanize .Name }}"
+description: ""
+lead: ""
+date: 2022-01-25T14:41:39+01:00
+lastmod: 2022-01-25T14:41:39+01:00
+draft: false
+images: []
+type: docs
+menu:
+  {{ .Section }}:
+    parent: "lorem"
+    identifier: "{{ .Name }}-{{ delimit (shuffle (split (md5 .Name) "" )) "" }}"
+weight: 100
+toc: true
+---
+
+In the following tutorial, you will do a thing and it will be _very_ cool. The thing will involve some concepts and technologies. Isn't learning just so much fun? Yay!
+
+If you encounter errors while completing this tutorial, see the [Troubleshooting]({{< relref "#troubleshooting">}}) section.  
+
+Before you begin, ensure that you meet the following prerequisites.
+
+## Prerequisites
+
+1. Prerequisite 1
+2. Prerequisite 2
+3. ...
+
+Now, begin the procedure.
+
+## Procedure
+
+{{< alert >}}
+<u>Remember</u>: I'm an ALERT, which means I can be used to get the reader to PAY ATTENTION TO SOMETHING IMPORTANT!!!!
+{{< /alert >}}
+
+1. I'm step 1.
+1. I'm step 2.
+   1. I'm a substep
+   1. ...
+1. I'm step 3
+1. ...
+
+Congratulations! You've successfully completed the tutorial. Now, check out the next steps.
+
+## Next Steps
+
+Now that you've successfully completed the tutorial, you can 
+- Try the following exercises that build on this tutorial 
+- Complete another related tutorial 
+- ...
+
+## Troubleshooting
+
+### Error 1 Description
+
+Description of resolution for error 1.
+
+### Error 2 Description
+
+Description of resolution for error 2.
+
+### Error 3 Description
+
+Description of resolution for error 3.


### PR DESCRIPTION
Hey @johnnymatthews, I'm using this PR to propose the creation of a tutorial template in `archetypes`.

This is just an initial draft that I'm hoping we can iterate on. Please lmk what you'd want to change / what else you think this template should have.

The structure proposed is:

- An opening paragraph that describes what the tutorial is.
- A prereqs section
- The core procedure section
- A next steps section 
  - The thought was that this section could either a) guide the reader to another related tutorial or part of the documentation or b) have some open ended exercises that we don't tell the reader how to complete, and they figure it out themselves
- A troubleshooting section
  - I remember from the Lotus docs tutorial that I recently worked on / you edited that there was some debate about having troubleshooting sections in a tutorial. I'd lean towards having a section in there by default, as its probably a better experience for the reader. But I guess it might also affect SEO, etc., so I figure we should discuss

(LMK if you'd like me to fork this repo and create this on the fork instead, and I'll delete this PR / branch. I saw you were creating feature and add branches, so I just figured I'd do the same thing.)